### PR TITLE
depreciate removed summary field

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -43,7 +43,6 @@ pub fn main() {
       "hook": true,
       "id": "1337",
       "name": "Awesome Game!!",
-      "summary": "",
       "type": 1
     }"#,
     )

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -38,7 +38,6 @@ pub struct DetectableActivity {
   pub rpc_origins: Option<Vec<String>>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub splash: Option<String>,
-  pub summary: String,
   #[serde(rename = "third_party_skus")]
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/server/process.rs
+++ b/src/server/process.rs
@@ -153,7 +153,6 @@ impl ProcessServer {
                 publishers: None,
                 rpc_origins: None,
                 splash: None,
-                summary: "".to_string(),
                 third_party_skus: None,
                 type_field: None,
                 verify_key: None,


### PR DESCRIPTION
## What does this PR do

As per observation of the latest version of `arrpc`'s [detectable.json](https://raw.githubusercontent.com/OpenAsar/arrpc/main/src/process/detectable.json), it seems like the `summary` field was removed entirely. This causes the current version to panic when trying to start with `./rsrpc -d ./detectable.json`.

This simply removes occurrences of the `summary` field. I hope I did not miss anything.