### PR TITLE
fix: Echo back IPC messages, fixes #13

### DIFF
--- a/lib/src/server/ipc_utils.rs
+++ b/lib/src/server/ipc_utils.rs
@@ -208,6 +208,17 @@ pub fn handle_stream(ipc: &mut dyn IpcFacilitator, stream: &mut Stream) {
           Ok(_) => (),
           Err(err) => log!("[IPC] Error sending activity command: {}", err),
         }
+
+        // "IPC will echo back every command you send as a response.
+        //  Use this as a lock-step feature to avoid flooding messages.
+        //  Can be used to validate messages such as the Presence or Subscribes."
+        // XXX: arRPC does some editing of the message, setting data.name: "", data.type: 0, evt: null etc... why?
+        let resp = encode(PacketType::Frame, message);
+
+        match stream.write_all(&resp) {
+          Ok(_) => (),
+          Err(err) => log!("[IPC] Error sending connection response: {}", err),
+        }
       }
       PacketType::Close => {
         log!("[IPC] Recieved close");


### PR DESCRIPTION
The IPC server is supposed to echo the messages back, this is used as an "ACK" for lock-step / avoiding flooding.

---

With many clients (for me it was [Keypunch](https://flathub.org/apps/dev.bragefuglseth.Keypunch), far easier to test than a minecraft mod) the server was not getting any IPC messages after the first one because the client was waiting for an echo response.

https://github.com/discord/discord-rpc/blob/master/documentation/hard-mode.md#notes

..why does arRPC do [all that](https://github.com/OpenAsar/arrpc/blob/2234e9c9111f4c42ebcc3aa6a2215bfd979eef77/src/server.js#L137-L145) to the message?