### PR TITLE
fix: improve process detection for relative paths

### DIFF
--- a/lib/src/server/process.rs
+++ b/lib/src/server/process.rs
@@ -330,6 +330,10 @@ impl ProcessServer {
           process_path = process_path.replace('\\', "/");
         }
 
+        if !process_path.starts_with('/') {
+          process_path.insert(0, '/');
+        }
+
         if !obs_open && (process_path.contains("obs64") || process_path.contains("streamlabs")) {
           obs_open = true;
         }


### PR DESCRIPTION
improves search patterns by adding a `/` to paths to fix relative paths (e.g., `retail/hitman3.exe` becomes `/retail/hitman3.exe`) and this fixes most games that dont start directly from steam (for example hitman by default opens a tiny launcher so you can change the settings before entering from there you press enter to enter the game).

and sorry for the double pr lol