### PR TITLE
fix: cli crashes when using --no-process-scan

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     ..Default::default()
   };
   let mut client = if args.no_process_scan {
-    rsrpc::RPCServer::from_json_str("{}", config).expect("Failed to create RPCServer")
+    rsrpc::RPCServer::from_json_str("[]", config).expect("Failed to create RPCServer")
   } else if let Some(file) = args.detectable_file {
     rsrpc::RPCServer::from_file(file, config).expect("Failed to create RPCServer")
   } else {


### PR DESCRIPTION
Thank you for maintaining this wonderful tool!

I found that running `rsrpc-cli` with the `--no-process-scan` flag causes it to terminate with the following error message:
```
thread 'main' (189347) panicked at lib/src/lib.rs:64:49:
Invalid JSON provided to RPCServer: Error("invalid type: map, expected a sequence", line: 1, column: 0)
```

This occurs because `"{}"` does not match the type required by the RPCServer.
```rs
let mut client = if args.no_process_scan {
  rsrpc::RPCServer::from_json_str("{}", config).expect("Failed to create RPCServer")
}
```