### PR TITLE
Hide console on Windows release builds

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
+
 use clap::Parser;
 use rsrpc::RPCConfig;
 use std::path::PathBuf;


### PR DESCRIPTION
windows has different subsystems that programs are compiled with. By default it uses the 'console' subsystem which will make the executing program spawn a commandline automatically to display stdout in. This is fine but if youre trying to run the application as a background process it will *always* open with an associated commandline window. Using the 'windows' subsystem fixes this problem. 

In this case i only have it apply for release builds, debug builds can still show the console which is useful for, well debugging